### PR TITLE
fix for vite 2.x & nuxt 3 

### DIFF
--- a/src/Steam64/index.ts
+++ b/src/Steam64/index.ts
@@ -1,7 +1,7 @@
 import { SteamID64, SteamIDAccount, SteamIDInstance, SteamIDType, SteamIDUniverse } from '../types';
 
 export default class Steam64 {
-  private value: bigint = 0n;
+  private value: bigint = BigInt(0);
 
   constructor(value?: SteamID64) {
     if (value) this.value = BigInt(value);
@@ -11,7 +11,7 @@ export default class Steam64 {
     const v = BigInt(value);
     const m = BigInt(mask);
     const o = BigInt(offset);
-    this.value = (this.value & -((m << o) + 1n)) | ((v & m) << o);
+    this.value = (this.value & -((m << o) + BigInt(1))) | ((v & m) << o);
   }
 
   private getBinPart(offset: number, mask: number): number {


### PR DESCRIPTION
As I know, this isn't bug of current lib. But, that is simplest way what I know to fix it.

```
 node_modules\@0x0c\steam-id\dist\Steam64\index.js:5:21: ERROR: Big integer literals are not available in the configured target environment ("es2019")  
 node_modules\@0x0c\steam-id\dist\Steam64\index.js:13:48: ERROR: Big integer literals are not available in the configured target environment ("es2019")
 ```
 
 I also try to build in es2020 or equal target. Maybe I do something wrong or vite didn't want to change target, so I failed :c 
 and I make this PR.